### PR TITLE
Remove `get()` in TokenCell

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -190,11 +190,6 @@ pub struct TokenCell<T: ?Sized, Token: TokenTrait> {
 impl<T: ?Sized, Token: TokenTrait> TokenCell<T, Token> {
     /// While cells are typically behind immutable references,
     /// obtaining a mutable reference to one is still proof of unique access.
-    pub fn get(&mut self) -> &T {
-        self.inner.get_mut()
-    }
-    /// While cells are typically behind immutable references,
-    /// obtaining a mutable reference to one is still proof of unique access.
     pub fn get_mut(&mut self) -> &mut T {
         self.inner.get_mut()
     }

--- a/src/monads.rs
+++ b/src/monads.rs
@@ -38,7 +38,7 @@ impl<
             Err(e) => Err((self, e)),
         }
     }
-    /// Apples the operation.
+    /// Applies the operation.
     pub fn apply(self, token: &'a Token) -> U
     where
         Token: TokenTrait<ComparisonError = Infallible>,
@@ -79,7 +79,7 @@ impl<
         let borrowed = self.cell.try_guard_mut(token)?;
         Ok((self.f)(borrowed))
     }
-    /// Apples the operation.
+    /// Applies the operation.
     pub fn apply(self, token: &'a mut Token) -> U
     where
         Token: TokenTrait<ComparisonError = Infallible>,


### PR DESCRIPTION
After bumping to 1.6.0, there is an error while compiling Zenoh
https://github.com/eclipse-zenoh/zenoh/issues/2122
Since we've already had Deref here, I think we don't need to repeat the `get()` here
https://github.com/p-avital/token-cell-rs/blob/8e9b304d8fd77e0c64f5908db7645d6ca3bc9491/src/core.rs#L210